### PR TITLE
Add missing required dep with middleware test

### DIFF
--- a/test/darkleaf/di/depencencies_test.clj
+++ b/test/darkleaf/di/depencencies_test.clj
@@ -30,16 +30,15 @@
 
 (defn c
   {::di/stop #(swap! % conj [`c :stopped])}
-  [{log ::log optional-false ::missing
-    :or {optional-false false}}]
-  (swap! log conj [`c :built optional-false])
+  [{log ::log}]
+  (swap! log conj [`c :built])
   log)
 
 (t/deftest order-test
   (let [log (atom [])]
     (-> (di/start `root {::log log})
         (di/stop))
-    (t/is (= [[`c :built false]
+    (t/is (= [[`c :built]
               [`a :built]
               [`b :built]
               [`root :built]

--- a/test/darkleaf/di/depencencies_test.clj
+++ b/test/darkleaf/di/depencencies_test.clj
@@ -30,15 +30,16 @@
 
 (defn c
   {::di/stop #(swap! % conj [`c :stopped])}
-  [{log ::log}]
-  (swap! log conj [`c :built])
+  [{log ::log optional-false ::missing
+    :or {optional-false false}}]
+  (swap! log conj [`c :built optional-false])
   log)
 
 (t/deftest order-test
   (let [log (atom [])]
     (-> (di/start `root {::log log})
         (di/stop))
-    (t/is (= [[`c :built]
+    (t/is (= [[`c :built false]
               [`a :built]
               [`b :built]
               [`root :built]

--- a/test/darkleaf/di/tutorial/n_env_test.clj
+++ b/test/darkleaf/di/tutorial/n_env_test.clj
@@ -34,6 +34,11 @@
     :or  {port 8080}}]
   [:jetty port])
 
+(defn jetty-required-port
+  {::di/kind :component}
+  [{port :env.long/PORT}]
+  [:jetty port])
+
 (t/deftest jetty-test
   (with-open [jetty (di/start `jetty
                               (di/env-parsing {:env.long parse-long}))]
@@ -41,4 +46,6 @@
   (with-open [jetty (di/start `jetty
                               (di/env-parsing :env.long parse-long)
                               {"PORT" "8081"})]
-    (t/is (= [:jetty 8081] @jetty))))
+    (t/is (= [:jetty 8081] @jetty)))
+  (t/is (thrown? clojure.lang.ExceptionInfo
+                 (di/start `jetty-required-port (di/env-parsing {:env.long parse-long})))))


### PR DESCRIPTION
Such dep appears as registered in registry, but builds to nil. Test verifies that this behavior is recognized as a missing dependency