### PR TITLE
Allow to return `nil` from a `defn` of a component

### DIFF
--- a/src/darkleaf/di/core.clj
+++ b/src/darkleaf/di/core.clj
@@ -651,19 +651,12 @@
 (defn- stop-fn [variable]
   (-> variable meta (::stop (fn no-op [_]))))
 
-(defn- validate-obj! [obj variable]
-  (when (nil? obj)
-    (throw (ex-info "A component fn must not return nil"
-                    {:type     ::nil-return
-                     :variable variable}))))
-
 (defn- var->0-component [variable]
   (let [stop (stop-fn variable)]
     (reify p/Factory
       (dependencies [_])
       (build [_ _ add-stop]
-        (let [obj (variable)]
-          (validate-obj! obj variable)
+        (let [obj (?? (variable) ::nil)]
           (add-stop #(stop obj))
           obj))
       (description [_]
@@ -676,8 +669,7 @@
       (dependencies [_]
         deps)
       (build [_ deps add-stop]
-        (let [obj (variable deps)]
-          (validate-obj! obj variable)
+        (let [obj (?? (variable deps) ::nil)]
           (add-stop #(stop obj))
           obj))
       (description [_]

--- a/test/darkleaf/di/component_test.clj
+++ b/test/darkleaf/di/component_test.clj
@@ -15,12 +15,12 @@
   nil)
 
 (t/deftest nil-component-0-arity-test
-  (let [ex (catch-some (di/start `nil-component-0-arity))]
-    (t/is (= ::di/nil-return (-> ex ex-cause ex-data :type)))))
+  (let [root (di/start `nil-component-0-arity)]
+    (t/is (= ::di/nil @root))))
 
 (t/deftest nil-component-1-arity-test
-  (let [ex (catch-some (di/start `nil-component-1-arity))]
-    (t/is (= ::di/nil-return (-> ex ex-cause ex-data :type)))))
+  (let [root (di/start `nil-component-1-arity)]
+    (t/is (= ::di/nil @root))))
 
 
 (defn component-2-arity


### PR DESCRIPTION
Мы уже несколько раз подорвались на коде вида

```clojure
(defn my-component [{flag `flag}]
  (when flag
    (side-effect)))
```

в тестах flag взведен, и все работает, т.к. `side-effect` у нас возвращает не `nil`,
но в проде он не взведен и приложение не запускается с ошибкой `"A component fn must not return nil"`

Можно было бы как-то внутри di вести учет nil компонентов, чтобы компонент для пользователя был настоящим `nil` но я что-то не могу придумать такого случая в реальности: 

```clojure
(defn other-component [{component `possible-nil-component
                        :or {component (create-default-impl ...)}}]
  ...)
```

в этом случае сам компонент должен вернуть дефолтную реализацию.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203924934293913